### PR TITLE
PF-48: Add API to get details of a incident

### DIFF
--- a/ABCall.swagger.yaml
+++ b/ABCall.swagger.yaml
@@ -1400,6 +1400,33 @@ paths:
         address: "${incidentquery_url}"
         protocol: h2
         path_translation: APPEND_PATH_TO_ADDRESS
+  /v1/incidents/{incidentId}:
+    get:
+      summary: Get incident
+      deprecated: false
+      description: ''
+      operationId: incidentGet
+      tags: []
+      parameters:
+        - name: incidentId
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: object
+            properties: {}
+      security:
+        - tokenAgent: []
+      produces:
+        - application/json
+      x-google-backend:
+        address: "${incidentquery_url}"
+        protocol: h2
+        path_translation: APPEND_PATH_TO_ADDRESS
   /v1/health/registroapp:
     get:
       summary: Health check


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint to retrieve details about specific incidents using `GET /v1/incidents/{incidentId}`.
  
- **Security**
	- The new endpoint requires a valid agent token for access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->