### PR TITLE
PF-319: Add API endpoint to receive emails

### DIFF
--- a/ABCall.swagger.yaml
+++ b/ABCall.swagger.yaml
@@ -1700,8 +1700,145 @@ paths:
         address: "${registroapp_url}"
         protocol: h2
         path_translation: APPEND_PATH_TO_ADDRESS
-
-
+  /v1/health/registromail:
+    get:
+      summary: Health check
+      deprecated: false
+      description: >-
+        This endpoint allows to check the health and availability of the
+        RegistroMail API endpoints. It returns a status code indicating the
+        health of the API.
+      operationId: healthRegistroMail
+      tags: []
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          headers: {}
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: Status
+            required:
+              - status
+      security: []
+      produces:
+        - application/json
+      x-google-backend:
+        address: "${registromail_url}"
+        protocol: h2
+        path_translation: APPEND_PATH_TO_ADDRESS
+  /v1/mail/receive:
+    post:
+      summary: Receive Webhook
+      deprecated: false
+      description: ''
+      operationId: mailReceive
+      tags: []
+      parameters:
+        - name: apikey
+          in: query
+          description: API key
+          required: false
+          type: string
+        - name: headers
+          in: formData
+          type: string
+          description: The raw headers of the email.
+        - name: dkim
+          in: formData
+          type: string
+          description: >-
+            A string containing the verification results of any DKIM and domain
+            keys signatures in the message.
+        - name: content-ids
+          in: formData
+          type: string
+          description: A string containing the number of attachments.
+        - name: to
+          in: formData
+          type: string
+          description: Email recipient field, as taken from the message headers.
+        - name: text
+          in: formData
+          type: string
+          description: Email body in plaintext formatting.
+        - name: html
+          in: formData
+          type: string
+          description: HTML body of email. If not set, email did not have an HTML body.
+        - name: from
+          in: formData
+          type: string
+          description: Email sender, as taken from the message headers.
+        - name: sender_ip
+          in: formData
+          type: string
+          description: A string of the sender's ip address.
+        - name: spam_report
+          in: formData
+          type: string
+          description: Spam Assassin's spam report.
+        - name: envelope
+          in: formData
+          type: string
+          description: >-
+            A string containing the SMTP envelope. This will have 2 variables:
+            to, which is a single-element array containing the address that we
+            received the email to, and from, which is the return path for the
+            message.
+        - name: attachments
+          in: formData
+          type: string
+          description: Number of attachments included in email.
+        - name: subject
+          in: formData
+          type: string
+          description: Email Subject.
+        - name: spam_score
+          in: formData
+          type: string
+          description: Spam Assassin's rating for whether or not this is spam.
+        - name: attachment-info
+          in: formData
+          type: string
+          description: >-
+            A JSON map where the keys are named attachment{X}. Each attachment
+            key points to a JSON object containing three fields, filename, type,
+            and content-id. The filename field is the name of the file (if it
+            was provided). The type field is the media type of the file. X is
+            the total number of attachments. For example, if the number of
+            attachments is 0, there will be no attachment files. If the number
+            of attachments is 3, parameters attachment1, attachment2, and
+            attachment3 will have file uploads.
+        - name: charsets
+          in: formData
+          type: string
+          description: >-
+            A string containing the character sets of the fields extracted from
+            the message.
+        - name: SPF
+          in: formData
+          type: string
+          description: >-
+            The results of the Sender Policy Framework verification of the
+            message sender and receiving IP address.
+      responses:
+        '201':
+          description: Created
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      x-google-backend:
+        address: "${registromail_url}"
+        protocol: h2
+        path_translation: APPEND_PATH_TO_ADDRESS
 swagger: '2.0'
 definitions:
   Error:

--- a/apigateway.tf
+++ b/apigateway.tf
@@ -43,6 +43,7 @@ locals {
     incidentmodify_url = "https://incidentmodify-${data.google_project.default.number}.${local.region}.run.app"
     incidentquery_url = "https://incidentquery-${data.google_project.default.number}.${local.region}.run.app"
     registroapp_url = "https://registroapp-${data.google_project.default.number}.${local.region}.run.app"
+    registromail_url = "https://registromail-${data.google_project.default.number}.${local.region}.run.app"
   })
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new API endpoints:
		- `GET /v1/health/registromail` for checking the health of the RegistroMail API.
		- `POST /v1/mail/receive` for receiving webhooks.
- **Improvements**
	- Added configurations for Google Cloud API Gateway services to enhance API management and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->